### PR TITLE
Watch game state for the end of the game.

### DIFF
--- a/src/sys/drop.rs
+++ b/src/sys/drop.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::time::Instant;
 use components as c;
 use settings;
+use specs::storage::MaskedStorage;
+use specs::shred::FetchMut;
 
 pub struct Dropper; 
 
@@ -19,14 +21,7 @@ impl<'a> System<'a> for Dropper {
         let (mut active, mut positions, mut clock, drop_speed, mut actions) = data;
         let time_since_drop = clock.last_drop.elapsed();
 
-        // Build the max_y_by_x for each value.
-        // Would like to separate this into another function or library for testability, but can't
-        // figure out the function signature /shrug
-        // In any case, we have a hashmap, bucketed by the x value, with the highest y value.
-        let mut max_y_by_x = HashMap::<u32, f64>::new();
-        for (active, pos) in (&active, &positions).join() {
-            max_y_by_x = map_check(active.0, pos.x as u32, pos.y, max_y_by_x);
-        }
+        let max_y_by_x = get_max_y_by_x(&active, &positions);
 
         for (active, pos, drop_speed) in (&mut active, &mut positions, &drop_speed).join() {
             // Only drop the active block.
@@ -66,6 +61,15 @@ fn map_check(active: bool, x: u32, y: f64, mut map: HashMap<u32, f64>) -> HashMa
         }
     }
     map
+}
+
+pub fn get_max_y_by_x(active_array: &Storage<c::Active, FetchMut<MaskedStorage<c::Active>>>,
+                      positions: &Storage<c::Position, FetchMut<MaskedStorage<c::Position>>>) -> HashMap<u32, f64> {
+    let mut max_y_by_x = HashMap::<u32, f64>::new();
+    for (active, pos) in (active_array, positions).join() {
+        max_y_by_x = map_check(active.0, pos.x as u32, pos.y, max_y_by_x);
+    }
+    max_y_by_x
 }
 
 

--- a/src/sys/ender.rs
+++ b/src/sys/ender.rs
@@ -1,16 +1,29 @@
 use specs::prelude::*;
 use components as c;
+use sys::drop::get_max_y_by_x;
 
 pub struct Ender;
 
 impl<'a> System<'a> for Ender {
     type SystemData = (ReadExpect<'a, c::KeysPressed>,
-                        WriteExpect<'a, c::KillProgram>);
+                       WriteExpect<'a, c::KillProgram>,
+                       WriteStorage<'a, c::Position>,
+                       WriteStorage<'a, c::Active>);
 
     fn run(&mut self, data: Self::SystemData) {
-        let (keys, mut kill) = data;
+        let (keys, mut kill, positions, active) = data;
         if keys.escape {
             kill.0 = true;
         }
+
+        let max_y_by_x = get_max_y_by_x(&active, &positions);
+
+        for value in max_y_by_x.values() {
+            if (*value as u32) == 0 {
+                println!("U luuuuuuu-se");
+                kill.0 = true
+            }
+        }
+
     }
 }


### PR DESCRIPTION
- If 'y' reaches '0' for any x, end the game.
- Factor out the 'max_y_by_x' functionality so that the Ender component can easily use it.