### PR TITLE
Implement L Block

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -15,9 +15,7 @@ pub struct Position {
 }
 
 #[derive(Component, Debug)]
-pub struct BlockOffsets(
-    pub [Offset; 4]
-);
+pub struct BlockOffsets(pub [Offset; 4]);
 
 #[derive(Component, Debug)]
 pub struct Dimensions {
@@ -35,7 +33,6 @@ pub struct Color {
 
 #[derive(Component, Debug)]
 pub struct DropSpeed(pub f64);
-
 
 #[derive(Component, Debug)]
 pub struct Active(pub bool);

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,10 +1,6 @@
+use settings;
 use specs::prelude::*;
-
-#[derive(Debug)]
-pub struct Offset {
-    pub x: i8,
-    pub y: i8,
-}
+use utils::*;
 
 /****** Components ******/
 
@@ -12,6 +8,38 @@ pub struct Offset {
 pub struct Position {
     pub x: f64,
     pub y: f64,
+}
+
+impl Position {
+    pub fn get_coords(&self) -> Coordinates {
+        let mut x = 0.0;
+        let mut y = 0.0;
+        if !(self.x == 0.0) {
+            x = self.x / (settings::RECT_WIDTH as f64);
+        }
+        if !(self.y == 0.0) {
+            y = self.y / (settings::RECT_HEIGHT as f64);
+        }
+        Coordinates {
+            x: (x as i16),
+            y: (y as i16),
+        }
+    }
+
+    pub fn get_offset_coords(&self, offset: &Offset) -> Coordinates {
+        let coords = self.get_coords();
+        Coordinates {
+            x: coords.x + (offset.x as i16),
+            y: coords.y + (offset.y as i16),
+        }
+    }
+
+    pub fn get_offset_position(&self, offset: &Offset) -> Position {
+        Position {
+            x: self.x + (offset.x as f64) * settings::RECT_WIDTH,
+            y: self.y + (offset.y as f64) * settings::RECT_HEIGHT,
+        }
+    }
 }
 
 #[derive(Component, Debug)]

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,5 +1,11 @@
 use specs::prelude::*;
 
+#[derive(Debug)]
+pub struct Offset {
+    pub x: i8,
+    pub y: i8,
+}
+
 /****** Components ******/
 
 #[derive(Component, Debug)]
@@ -7,6 +13,11 @@ pub struct Position {
     pub x: f64,
     pub y: f64,
 }
+
+#[derive(Component, Debug)]
+pub struct BlockOffsets(
+    pub [Offset; 4]
+);
 
 #[derive(Component, Debug)]
 pub struct Dimensions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,16 @@ extern crate specs;
 #[macro_use]
 extern crate specs_derive;
 
-mod sys;
 mod components;
 mod resources;
+mod sys;
 
-use piston_window::*;
-use specs::prelude::*;
-use std::time::Instant;
-use std::collections::HashMap;
 use components as c;
+use piston_window::*;
 use resources as r;
+use specs::prelude::*;
+use std::collections::HashMap;
+use std::time::Instant;
 
 /****** Constants ******/
 
@@ -44,14 +44,15 @@ fn ecs_demo() {
 
     let mut dispatcher = DispatcherBuilder::new()
         .with(sys::drop::Dropper, "dropper", &[])
-        .with(sys::spawn::BlockSpawner, "spawner", &[]) 
+        .with(sys::spawn::BlockSpawner, "spawner", &[])
         .with(sys::movement::Movement, "movement", &[])
         .with(sys::ender::Ender, "ender", &[])
         .with(sys::map::Mapper, "mapper", &[])
-        .with_thread_local(sys::piston_wrap::PistonWrapper{ window: window })
+        .with_thread_local(sys::piston_wrap::PistonWrapper { window: window })
         .build();
 
-    while !world.read_resource::<r::KillProgram>().0 { //press esc while playing to end the loop
+    while !world.read_resource::<r::KillProgram>().0 {
+        //press esc while playing to end the loop
         dispatcher.dispatch(&mut world.res);
         world.maintain();
     }
@@ -84,7 +85,7 @@ fn init_world() -> World {
         last_spawn: Instant::now(),
     });
     world.add_resource(r::KillProgram(false));
-    world.add_resource( r::GameMap(HashMap::<u32,f64>::new()) );
+    world.add_resource(r::GameMap(HashMap::<u32, f64>::new()));
 
     world
         .create_entity()
@@ -93,12 +94,12 @@ fn init_world() -> World {
             width: settings::RECT_WIDTH,
             height: settings::RECT_HEIGHT,
         })
-        .with(c::BlockOffsets (
-            [c::Offset {x: 0, y: 0},
-            c::Offset {x: 1, y: 0}, 
-            c::Offset {x: 0, y: -1}, 
-            c::Offset {x: 0, y: -2}]
-        ))
+        .with(c::BlockOffsets([
+            c::Offset { x: 0, y: 0 },
+            c::Offset { x: 1, y: 0 },
+            c::Offset { x: 0, y: -1 },
+            c::Offset { x: 0, y: -2 },
+        ]))
         .with(c::Color {
             r: 1.0,
             g: 0.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,7 @@ fn init_world() -> World {
     world.register::<c::Color>();
     world.register::<c::DropSpeed>();
     world.register::<c::Active>();
+    world.register::<c::BlockOffsets>();
 
     world.add_resource(r::KeysPressed {
         left: false,
@@ -92,6 +93,12 @@ fn init_world() -> World {
             width: settings::RECT_WIDTH,
             height: settings::RECT_HEIGHT,
         })
+        .with(c::BlockOffsets (
+            [c::Offset {x: 0, y: 0},
+            c::Offset {x: 1, y: 0}, 
+            c::Offset {x: 0, y: -1}, 
+            c::Offset {x: 0, y: -2}]
+        ))
         .with(c::Color {
             r: 1.0,
             g: 0.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use components as c;
 use piston_window::*;
 use resources as r;
 use specs::prelude::*;
-use std::collections::HashMap;
 use std::time::Instant;
 use utils::Offset;
 
@@ -104,10 +103,10 @@ fn init_kill_program(world: &mut World) {
 }
 
 fn init_game_map(world: &mut World) {
-    world.add_resource(r::GameMap(HashMap::<u32, f64>::new()));
-    world.add_resource(r::GameMap2(
-        [[0; (settings::NUMBER_OF_CELLS_HIGH as usize)]; (settings::NUMBER_OF_CELLS_WIDE as usize)],
-    ))
+    world.add_resource(r::GameMap {
+        map: [[false; (settings::NUMBER_OF_CELLS_HIGH as usize)];
+            (settings::NUMBER_OF_CELLS_WIDE as usize)],
+    })
 }
 
 fn spawn_initial_block(world: &mut World) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate specs_derive;
 mod components;
 mod resources;
 mod sys;
+mod utils;
 
 use components as c;
 use piston_window::*;
@@ -13,6 +14,7 @@ use resources as r;
 use specs::prelude::*;
 use std::collections::HashMap;
 use std::time::Instant;
+use utils::Offset;
 
 /****** Constants ******/
 
@@ -103,6 +105,9 @@ fn init_kill_program(world: &mut World) {
 
 fn init_game_map(world: &mut World) {
     world.add_resource(r::GameMap(HashMap::<u32, f64>::new()));
+    world.add_resource(r::GameMap2(
+        [[0; (settings::NUMBER_OF_CELLS_HIGH as usize)]; (settings::NUMBER_OF_CELLS_WIDE as usize)],
+    ))
 }
 
 fn spawn_initial_block(world: &mut World) {
@@ -114,10 +119,10 @@ fn spawn_initial_block(world: &mut World) {
             height: settings::RECT_HEIGHT,
         })
         .with(c::BlockOffsets([
-            c::Offset { x: 0, y: 0 },
-            c::Offset { x: 1, y: 0 },
-            c::Offset { x: 0, y: -1 },
-            c::Offset { x: 0, y: -2 },
+            Offset { x: 0, y: 0 },
+            Offset { x: 1, y: 0 },
+            Offset { x: 0, y: -1 },
+            Offset { x: 0, y: -2 },
         ]))
         .with(c::Color {
             r: 1.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,13 @@ use resources as r;
 // R: 800 by 640 seems to not quite fit on my laptop screen.
 // Since window resize does not scale the map, blocks will be chopped off at the bottom of my screen.
 mod settings {
-    pub const WINDOW_HEIGHT: u32 = 625;
-    pub const WINDOW_WIDTH: u32 = 500;
+    pub const WINDOW_HEIGHT: u32 = 600;
+    pub const WINDOW_WIDTH: u32 = 300;
     pub const WINDOW_DIMENSIONS: [u32; 2] = [WINDOW_WIDTH, WINDOW_HEIGHT];
-    pub const RECT_WIDTH: f64 = (WINDOW_WIDTH as f64) / 8.0;
-    pub const RECT_HEIGHT: f64 = (WINDOW_HEIGHT as f64) / 10.0;
+    pub const NUMBER_OF_CELLS_WIDE: u16 = 10;
+    pub const NUMBER_OF_CELLS_HIGH: u16 = 20;
+    pub const RECT_WIDTH: f64 = (WINDOW_WIDTH as f64) / (NUMBER_OF_CELLS_WIDE as f64);
+    pub const RECT_HEIGHT: f64 = (WINDOW_HEIGHT as f64) / (NUMBER_OF_CELLS_HIGH as f64);
     pub const NANOS_PER_SECOND: f64 = 1000000000.0;
     pub const MAX_MOVE_SPEED: f64 = 0.05;
     pub const MAX_SPAWN_SPEED: f64 = 0.5;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -29,6 +29,6 @@ pub struct KillProgram(pub bool);
 pub struct GameMap(pub HashMap<u32, f64>);
 
 pub struct GameMap2(
-    pub  [[i8; (settings::NUMBER_OF_CELLS_HIGH as usize)];
+    pub  [[i16; (settings::NUMBER_OF_CELLS_HIGH as usize)];
         (settings::NUMBER_OF_CELLS_WIDE as usize)],
 );

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -28,4 +28,7 @@ pub struct KillProgram(pub bool);
 
 pub struct GameMap(pub HashMap<u32, f64>);
 
-pub struct GameMap2(pub [[i8; settings::NUMBER_OF_CELLS_HIGH]; settings::NUMBER_OF_CELLS_WIDE]);
+pub struct GameMap2(
+    pub  [[i8; (settings::NUMBER_OF_CELLS_HIGH as usize)];
+        (settings::NUMBER_OF_CELLS_WIDE as usize)],
+);

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,6 +1,6 @@
 use settings;
-use std::collections::HashMap;
 use std::time::Instant;
+use utils::*;
 
 /****** Resources ******/
 
@@ -26,9 +26,40 @@ pub struct Actions {
 
 pub struct KillProgram(pub bool);
 
-pub struct GameMap(pub HashMap<u32, f64>);
-
-pub struct GameMap2(
-    pub  [[i16; (settings::NUMBER_OF_CELLS_HIGH as usize)];
+pub struct GameMap {
+    pub map: [[bool; (settings::NUMBER_OF_CELLS_HIGH as usize)];
         (settings::NUMBER_OF_CELLS_WIDE as usize)],
-);
+}
+
+impl GameMap {
+    pub fn get(&self, coords: &Coordinates) -> bool {
+        if self.in_bounds(coords) {
+            return self.map[(coords.x as usize)][(coords.y as usize)];
+        }
+        false
+    }
+
+    pub fn set(&mut self, coords: &Coordinates, value: bool) {
+        if self.in_bounds(coords) {
+            self.map[(coords.x as usize)][(coords.y as usize)] = value;
+        }
+    }
+
+    pub fn limit_break(&self, coords: &Coordinates) -> bool {
+        if coords.y < 0 {
+            return true;
+        }
+        false
+    }
+
+    pub fn in_bounds(&self, coords: &Coordinates) -> bool {
+        if coords.x < 0 || coords.y < 0 {
+            return false;
+        } else if coords.x >= (settings::NUMBER_OF_CELLS_WIDE as i16) {
+            return false;
+        } else if coords.y >= (settings::NUMBER_OF_CELLS_HIGH as i16) {
+            return false;
+        }
+        true
+    }
+}

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,5 +1,6 @@
-use std::time::Instant;
+use settings;
 use std::collections::HashMap;
+use std::time::Instant;
 
 /****** Resources ******/
 
@@ -25,4 +26,6 @@ pub struct Actions {
 
 pub struct KillProgram(pub bool);
 
-pub struct GameMap (pub HashMap<u32, f64>);
+pub struct GameMap(pub HashMap<u32, f64>);
+
+pub struct GameMap2(pub [[i8; settings::NUMBER_OF_CELLS_HIGH]; settings::NUMBER_OF_CELLS_WIDE]);

--- a/src/sys/drop.rs
+++ b/src/sys/drop.rs
@@ -10,35 +10,38 @@ impl<'a> System<'a> for Dropper {
     type SystemData = (
         WriteStorage<'a, c::Active>,
         WriteStorage<'a, c::Position>,
+        ReadStorage<'a, c::BlockOffsets>,
         WriteExpect<'a, r::Clock>,
         ReadStorage<'a, c::DropSpeed>,
         WriteExpect<'a, r::Actions>,
-        ReadExpect<'a, r::GameMap>,
+        ReadExpect<'a, r::GameMap>
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (mut active, mut positions, mut clock, drop_speed, mut actions, map) = data;
+        let (mut active, mut positions, offsets, mut clock, drop_speed, mut actions, map) = data;
         let time_since_drop = clock.last_drop.elapsed();
 
-        for (active, pos, drop_speed) in (&mut active, &mut positions, &drop_speed).join() {
+        for (active, pos, drop_speed, offsets) in (&mut active, &mut positions, &drop_speed, &offsets).join() {
             // Only drop the active block.
             if active.0 {
                 // drop blocks down
                 let y_delta = time_since_drop.subsec_nanos() as f64 * drop_speed.0 / settings::NANOS_PER_SECOND;
                 pos.y = (pos.y + y_delta) % (settings::WINDOW_HEIGHT as f64);
 
-                // compare active block with existing blocks on map 
-                let y_max = match map.0.get(&(pos.x as u32)) {
-                    Some(&pos_y) => pos_y,
-                    None         => (settings::WINDOW_HEIGHT as f64) - (settings::RECT_HEIGHT)
-                };
+                for offset in offsets.0.iter() {
+                    let x = pos.x + (offset.x as f64) * settings::RECT_WIDTH;
+                    let y = pos.y + (offset.y as f64) * settings::RECT_HEIGHT;
+                    let y_max = match map.0.get(&(x as u32)) {
+                        Some(&pos_y) => pos_y,
+                        None         => (settings::WINDOW_HEIGHT as f64) - (settings::RECT_HEIGHT)
+                    };
+                    if y >= y_max {
+                        pos.y = y_max; 
+                        active.0 = false; 
+                        actions.spawn_block = true;
+                    } 
+                }
 
-                if pos.y >= y_max {
-                    // Block has hit bottom of screen.
-                    pos.y = y_max; 
-                    active.0 = false; 
-                    actions.spawn_block = true;
-                } 
                 clock.last_drop = Instant::now();
             }
         }   

--- a/src/sys/drop.rs
+++ b/src/sys/drop.rs
@@ -1,10 +1,10 @@
-use specs::prelude::*;
-use std::time::Instant;
 use components as c;
 use resources as r;
 use settings;
+use specs::prelude::*;
+use std::time::Instant;
 
-pub struct Dropper; 
+pub struct Dropper;
 
 impl<'a> System<'a> for Dropper {
     type SystemData = (
@@ -14,18 +14,21 @@ impl<'a> System<'a> for Dropper {
         WriteExpect<'a, r::Clock>,
         ReadStorage<'a, c::DropSpeed>,
         WriteExpect<'a, r::Actions>,
-        ReadExpect<'a, r::GameMap>
+        ReadExpect<'a, r::GameMap>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
         let (mut active, mut positions, offsets, mut clock, drop_speed, mut actions, map) = data;
         let time_since_drop = clock.last_drop.elapsed();
 
-        for (active, pos, drop_speed, offsets) in (&mut active, &mut positions, &drop_speed, &offsets).join() {
+        for (active, pos, drop_speed, offsets) in
+            (&mut active, &mut positions, &drop_speed, &offsets).join()
+        {
             // Only drop the active block.
             if active.0 {
                 // drop blocks down
-                let y_delta = time_since_drop.subsec_nanos() as f64 * drop_speed.0 / settings::NANOS_PER_SECOND;
+                let y_delta = time_since_drop.subsec_nanos() as f64 * drop_speed.0
+                    / settings::NANOS_PER_SECOND;
                 pos.y = (pos.y + y_delta) % (settings::WINDOW_HEIGHT as f64);
 
                 for offset in offsets.0.iter() {
@@ -33,18 +36,17 @@ impl<'a> System<'a> for Dropper {
                     let y = pos.y + (offset.y as f64) * settings::RECT_HEIGHT;
                     let y_max = match map.0.get(&(x as u32)) {
                         Some(&pos_y) => pos_y,
-                        None         => (settings::WINDOW_HEIGHT as f64) - (settings::RECT_HEIGHT)
+                        None => (settings::WINDOW_HEIGHT as f64) - (settings::RECT_HEIGHT),
                     };
                     if y >= y_max {
-                        pos.y = y_max; 
-                        active.0 = false; 
+                        pos.y = y_max;
+                        active.0 = false;
                         actions.spawn_block = true;
-                    } 
+                    }
                 }
 
                 clock.last_drop = Instant::now();
             }
-        }   
+        }
     }
 }
-

--- a/src/sys/ender.rs
+++ b/src/sys/ender.rs
@@ -1,12 +1,14 @@
-use specs::prelude::*;
 use resources as r;
+use specs::prelude::*;
 
 pub struct Ender;
 
 impl<'a> System<'a> for Ender {
-    type SystemData = (ReadExpect<'a, r::KeysPressed>,
-                        WriteExpect<'a, r::KillProgram>,
-                        ReadExpect<'a, r::GameMap>);
+    type SystemData = (
+        ReadExpect<'a, r::KeysPressed>,
+        WriteExpect<'a, r::KillProgram>,
+        ReadExpect<'a, r::GameMap>,
+    );
 
     fn run(&mut self, data: Self::SystemData) {
         let (keys, mut kill, map) = data;
@@ -20,6 +22,5 @@ impl<'a> System<'a> for Ender {
                 kill.0 = true
             }
         }
-
     }
 }

--- a/src/sys/ender.rs
+++ b/src/sys/ender.rs
@@ -15,12 +15,5 @@ impl<'a> System<'a> for Ender {
         if keys.escape {
             kill.0 = true;
         }
-
-        for value in map.0.values() {
-            if (*value as u32) == 0 {
-                println!("U luuuuuuu-se");
-                kill.0 = true
-            }
-        }
     }
 }

--- a/src/sys/ender.rs
+++ b/src/sys/ender.rs
@@ -7,11 +7,10 @@ impl<'a> System<'a> for Ender {
     type SystemData = (
         ReadExpect<'a, r::KeysPressed>,
         WriteExpect<'a, r::KillProgram>,
-        ReadExpect<'a, r::GameMap>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (keys, mut kill, map) = data;
+        let (keys, mut kill) = data;
         if keys.escape {
             kill.0 = true;
         }

--- a/src/sys/map.rs
+++ b/src/sys/map.rs
@@ -1,8 +1,6 @@
 use components as c;
 use resources as r;
-use settings;
 use specs::prelude::*;
-use std::collections::HashMap;
 use utils::Offset;
 
 pub struct Mapper;
@@ -13,37 +11,33 @@ impl<'a> System<'a> for Mapper {
         ReadStorage<'a, c::BlockOffsets>,
         WriteExpect<'a, r::GameMap>,
         ReadStorage<'a, c::Active>,
+        WriteExpect<'a, r::KillProgram>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (positions, offsets, mut map, actives) = data;
+        let (positions, offsets, mut map, actives, mut kill) = data;
 
-        // for all active blocks, update the map with their y value
+        // for all inactive blocks, update the map with their values
         for (active, pos, offsets) in (&actives, &positions, &offsets).join() {
-            update_map(active.0, pos.x as u32, pos.y, &mut map.0, &offsets.0);
+            update_map(active.0, pos, &mut map, &offsets.0, &mut kill);
         }
     }
 }
 
-fn update_map(active: bool, x: u32, y: f64, map: &mut HashMap<u32, f64>, offsets: &[Offset; 4]) {
+fn update_map(
+    active: bool,
+    pos: &c::Position,
+    map: &mut WriteExpect<r::GameMap>,
+    offsets: &[Offset; 4],
+    kill: &mut WriteExpect<r::KillProgram>,
+) {
     if !active {
         for offset in offsets {
-            let x_offset = (offset.x as f64) * settings::RECT_WIDTH;
-            let y_offset = (offset.y as f64) * settings::RECT_HEIGHT;
-            add_to_map(x + (x_offset as u32), y + y_offset, map)
-        }
-    }
-}
-
-fn add_to_map(x: u32, y: f64, map: &mut HashMap<u32, f64>) {
-    match map.get(&x) {
-        Some(&y_found) => {
-            if (y - settings::RECT_HEIGHT) < y_found {
-                map.insert(x, y - settings::RECT_HEIGHT);
+            let coords = pos.get_offset_coords(offset);
+            if map.limit_break(&coords) {
+                kill.0 = true;
             }
-        }
-        None => {
-            map.insert(x, y - settings::RECT_HEIGHT);
+            map.set(&coords, true);
         }
     }
 }

--- a/src/sys/map.rs
+++ b/src/sys/map.rs
@@ -3,6 +3,7 @@ use resources as r;
 use settings;
 use specs::prelude::*;
 use std::collections::HashMap;
+use utils::Offset;
 
 pub struct Mapper;
 
@@ -24,7 +25,7 @@ impl<'a> System<'a> for Mapper {
     }
 }
 
-fn update_map(active: bool, x: u32, y: f64, map: &mut HashMap<u32, f64>, offsets: &[c::Offset; 4]) {
+fn update_map(active: bool, x: u32, y: f64, map: &mut HashMap<u32, f64>, offsets: &[Offset; 4]) {
     if !active {
         for offset in offsets {
             let x_offset = (offset.x as f64) * settings::RECT_WIDTH;

--- a/src/sys/map.rs
+++ b/src/sys/map.rs
@@ -1,17 +1,17 @@
-use specs::prelude::*;
-use std::collections::HashMap;
 use components as c;
 use resources as r;
 use settings;
+use specs::prelude::*;
+use std::collections::HashMap;
 
-pub struct Mapper; 
+pub struct Mapper;
 
 impl<'a> System<'a> for Mapper {
     type SystemData = (
         WriteStorage<'a, c::Position>,
         ReadStorage<'a, c::BlockOffsets>,
         WriteExpect<'a, r::GameMap>,
-        ReadStorage<'a, c::Active>
+        ReadStorage<'a, c::Active>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
@@ -20,7 +20,7 @@ impl<'a> System<'a> for Mapper {
         // for all active blocks, update the map with their y value
         for (active, pos, offsets) in (&actives, &positions, &offsets).join() {
             update_map(active.0, pos.x as u32, pos.y, &mut map.0, &offsets.0);
-        }   
+        }
     }
 }
 

--- a/src/sys/map.rs
+++ b/src/sys/map.rs
@@ -9,31 +9,40 @@ pub struct Mapper;
 impl<'a> System<'a> for Mapper {
     type SystemData = (
         WriteStorage<'a, c::Position>,
+        ReadStorage<'a, c::BlockOffsets>,
         WriteExpect<'a, r::GameMap>,
         ReadStorage<'a, c::Active>
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (positions, mut map, actives) = data;
+        let (positions, offsets, mut map, actives) = data;
 
         // for all active blocks, update the map with their y value
-        for (active, pos) in (&actives, &positions).join() {
-            update_map(active.0, pos.x as u32, pos.y, &mut map.0);
+        for (active, pos, offsets) in (&actives, &positions, &offsets).join() {
+            update_map(active.0, pos.x as u32, pos.y, &mut map.0, &offsets.0);
         }   
     }
 }
 
-fn update_map(active: bool, x: u32, y: f64, map: &mut HashMap<u32, f64>) {
+fn update_map(active: bool, x: u32, y: f64, map: &mut HashMap<u32, f64>, offsets: &[c::Offset; 4]) {
     if !active {
-        match map.get(&x) {
-            Some(&y_found) => {
-                if (y - settings::RECT_HEIGHT) < y_found {
-                    map.insert(x, y - settings::RECT_HEIGHT);
-                }
-            }
-            None => {
+        for offset in offsets {
+            let x_offset = (offset.x as f64) * settings::RECT_WIDTH;
+            let y_offset = (offset.y as f64) * settings::RECT_HEIGHT;
+            add_to_map(x + (x_offset as u32), y + y_offset, map)
+        }
+    }
+}
+
+fn add_to_map(x: u32, y: f64, map: &mut HashMap<u32, f64>) {
+    match map.get(&x) {
+        Some(&y_found) => {
+            if (y - settings::RECT_HEIGHT) < y_found {
                 map.insert(x, y - settings::RECT_HEIGHT);
             }
+        }
+        None => {
+            map.insert(x, y - settings::RECT_HEIGHT);
         }
     }
 }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,6 +1,6 @@
 pub mod drop;
-pub mod movement;
-pub mod spawn;
-pub mod piston_wrap;
 pub mod ender;
 pub mod map;
+pub mod movement;
+pub mod piston_wrap;
+pub mod spawn;

--- a/src/sys/movement.rs
+++ b/src/sys/movement.rs
@@ -36,7 +36,7 @@ impl<'a> System<'a> for Movement {
                 }
                 if actions.move_left {
                     if secs_since_move > settings::MAX_MOVE_SPEED {
-                        pos.x = pos.x - settings::RECT_HEIGHT;
+                        pos.x = pos.x - settings::RECT_WIDTH;
                         if pos.x < 0.0 {
                             pos.x = window_width - settings::RECT_WIDTH
                         }

--- a/src/sys/movement.rs
+++ b/src/sys/movement.rs
@@ -1,8 +1,8 @@
-use specs::prelude::*;
-use settings;
-use std::time::Instant;
 use components as c;
 use resources as r;
+use settings;
+use specs::prelude::*;
+use std::time::Instant;
 
 pub struct Movement;
 
@@ -11,7 +11,7 @@ impl<'a> System<'a> for Movement {
         WriteStorage<'a, c::Active>,
         WriteStorage<'a, c::Position>,
         WriteExpect<'a, r::Clock>,
-        WriteExpect<'a, r::Actions>
+        WriteExpect<'a, r::Actions>,
     );
 
     fn run(&mut self, data: Self::SystemData) {

--- a/src/sys/movement.rs
+++ b/src/sys/movement.rs
@@ -11,7 +11,7 @@ impl<'a> System<'a> for Movement {
         WriteStorage<'a, c::Active>,
         WriteStorage<'a, c::Position>,
         WriteExpect<'a, r::Clock>,
-        WriteExpect<'a, r::Actions>,
+        WriteExpect<'a, r::Actions>
     );
 
     fn run(&mut self, data: Self::SystemData) {

--- a/src/sys/piston_wrap.rs
+++ b/src/sys/piston_wrap.rs
@@ -1,9 +1,9 @@
-use specs::prelude::*;
-use piston_window::*;
-use Button;
 use components as c;
+use piston_window::*;
 use resources as r;
 use settings;
+use specs::prelude::*;
+use Button;
 
 pub struct PistonWrapper {
     pub window: PistonWindow,
@@ -16,7 +16,7 @@ impl<'a> System<'a> for PistonWrapper {
         ReadStorage<'a, c::BlockOffsets>,
         ReadStorage<'a, c::Color>,
         WriteExpect<'a, r::KeysPressed>,
-        WriteExpect<'a, r::Actions>
+        WriteExpect<'a, r::Actions>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
@@ -56,7 +56,7 @@ impl<'a> System<'a> for PistonWrapper {
                 clear_window(graphics);
                 for (pos, dim, color, offsets) in (&pos, &dim, &color, &offsets).join() {
                     draw_shape(pos, dim, color, &offsets.0, context, graphics);
-                } 
+                }
             });
         }
     }
@@ -66,8 +66,14 @@ fn clear_window(graphics: &mut piston_window::G2d) {
     clear([1.0; 4], graphics);
 }
 
-fn draw_shape(pos: &c::Position, dim: &c::Dimensions, color: &c::Color, offsets: &[c::Offset; 4], 
-                context: piston_window::context::Context, graphics: &mut piston_window::G2d) {
+fn draw_shape(
+    pos: &c::Position,
+    dim: &c::Dimensions,
+    color: &c::Color,
+    offsets: &[c::Offset; 4],
+    context: piston_window::context::Context,
+    graphics: &mut piston_window::G2d,
+) {
     for offset in offsets.iter() {
         let x = pos.x + (offset.x as f64) * settings::RECT_WIDTH;
         let y = pos.y + (offset.y as f64) * settings::RECT_HEIGHT;

--- a/src/sys/piston_wrap.rs
+++ b/src/sys/piston_wrap.rs
@@ -1,7 +1,6 @@
 use components as c;
 use piston_window::*;
 use resources as r;
-use settings;
 use specs::prelude::*;
 use utils::Offset;
 use Button;

--- a/src/sys/piston_wrap.rs
+++ b/src/sys/piston_wrap.rs
@@ -3,6 +3,7 @@ use piston_window::*;
 use Button;
 use components as c;
 use resources as r;
+use settings;
 
 pub struct PistonWrapper {
     pub window: PistonWindow,
@@ -12,13 +13,14 @@ impl<'a> System<'a> for PistonWrapper {
     type SystemData = (
         ReadStorage<'a, c::Position>,
         ReadStorage<'a, c::Dimensions>,
+        ReadStorage<'a, c::BlockOffsets>,
         ReadStorage<'a, c::Color>,
         WriteExpect<'a, r::KeysPressed>,
-        WriteExpect<'a, r::Actions>,
+        WriteExpect<'a, r::Actions>
     );
 
     fn run(&mut self, data: Self::SystemData) {
-        let (pos, dim, color, mut keys, mut actions) = data;
+        let (pos, dim, offsets, color, mut keys, mut actions) = data;
 
         if let Some(event) = self.window.next() {
             // saving user Movement for process by other systems
@@ -50,17 +52,30 @@ impl<'a> System<'a> for PistonWrapper {
                 _ => {}
             }
 
-            // updating graphics
             self.window.draw_2d(&event, |context, graphics| {
-                clear([1.0; 4], graphics);
-
-                //for all entities with pos, dim, and color properties (i.e. rect)
-                for (pos, dim, color) in (&pos, &dim, &color).join() {
-                    let temp_rect = [pos.x, pos.y, dim.width, dim.height];
-                    let temp_color = [color.r, color.g, color.b, color.a];
-                    rectangle(temp_color, temp_rect, context.transform, graphics);
-                }
+                clear_window(graphics);
+                for (pos, dim, color, offsets) in (&pos, &dim, &color, &offsets).join() {
+                    draw_shape(pos, dim, color, offsets, context, graphics);
+                } 
             });
         }
     }
+}
+
+fn clear_window(graphics: &mut piston_window::G2d) {
+    clear([1.0; 4], graphics);
+}
+
+fn draw_shape(pos: &c::Position, dim: &c::Dimensions, color: &c::Color, offsets: &c::BlockOffsets, 
+                context: piston_window::context::Context, graphics: &mut piston_window::G2d) {
+    for offset in offsets.0.iter() {
+        let x = pos.x + (offset.x as f64) * settings::RECT_WIDTH;
+        let y = pos.y + (offset.y as f64) * settings::RECT_HEIGHT;
+        let temp_rect = [x, y, dim.width, dim.height];
+        let temp_color = [color.r, color.g, color.b, color.a];
+        rectangle(temp_color, temp_rect, context.transform, graphics);
+    }
+    let temp_rect = [pos.x, pos.y, dim.width, dim.height];
+    let temp_color = [color.r, color.g, color.b, color.a];
+    rectangle(temp_color, temp_rect, context.transform, graphics);
 }

--- a/src/sys/piston_wrap.rs
+++ b/src/sys/piston_wrap.rs
@@ -55,7 +55,7 @@ impl<'a> System<'a> for PistonWrapper {
             self.window.draw_2d(&event, |context, graphics| {
                 clear_window(graphics);
                 for (pos, dim, color, offsets) in (&pos, &dim, &color, &offsets).join() {
-                    draw_shape(pos, dim, color, offsets, context, graphics);
+                    draw_shape(pos, dim, color, &offsets.0, context, graphics);
                 } 
             });
         }
@@ -66,16 +66,13 @@ fn clear_window(graphics: &mut piston_window::G2d) {
     clear([1.0; 4], graphics);
 }
 
-fn draw_shape(pos: &c::Position, dim: &c::Dimensions, color: &c::Color, offsets: &c::BlockOffsets, 
+fn draw_shape(pos: &c::Position, dim: &c::Dimensions, color: &c::Color, offsets: &[c::Offset; 4], 
                 context: piston_window::context::Context, graphics: &mut piston_window::G2d) {
-    for offset in offsets.0.iter() {
+    for offset in offsets.iter() {
         let x = pos.x + (offset.x as f64) * settings::RECT_WIDTH;
         let y = pos.y + (offset.y as f64) * settings::RECT_HEIGHT;
         let temp_rect = [x, y, dim.width, dim.height];
         let temp_color = [color.r, color.g, color.b, color.a];
         rectangle(temp_color, temp_rect, context.transform, graphics);
     }
-    let temp_rect = [pos.x, pos.y, dim.width, dim.height];
-    let temp_color = [color.r, color.g, color.b, color.a];
-    rectangle(temp_color, temp_rect, context.transform, graphics);
 }

--- a/src/sys/piston_wrap.rs
+++ b/src/sys/piston_wrap.rs
@@ -3,6 +3,7 @@ use piston_window::*;
 use resources as r;
 use settings;
 use specs::prelude::*;
+use utils::Offset;
 use Button;
 
 pub struct PistonWrapper {
@@ -70,15 +71,25 @@ fn draw_shape(
     pos: &c::Position,
     dim: &c::Dimensions,
     color: &c::Color,
-    offsets: &[c::Offset; 4],
+    offsets: &[Offset; 4],
     context: piston_window::context::Context,
     graphics: &mut piston_window::G2d,
 ) {
     for offset in offsets.iter() {
-        let x = pos.x + (offset.x as f64) * settings::RECT_WIDTH;
-        let y = pos.y + (offset.y as f64) * settings::RECT_HEIGHT;
-        let temp_rect = [x, y, dim.width, dim.height];
-        let temp_color = [color.r, color.g, color.b, color.a];
-        rectangle(temp_color, temp_rect, context.transform, graphics);
+        let off_pos = pos.get_offset_position(offset);
+        rectangle(
+            build_color(&color),
+            build_rect(&off_pos, &dim),
+            context.transform,
+            graphics,
+        );
     }
+}
+
+fn build_rect(pos: &c::Position, dim: &c::Dimensions) -> [f64; 4] {
+    [pos.x, pos.y, dim.width, dim.height]
+}
+
+fn build_color(color: &c::Color) -> [f32; 4] {
+    [color.r, color.g, color.b, color.a]
 }

--- a/src/sys/spawn.rs
+++ b/src/sys/spawn.rs
@@ -1,7 +1,7 @@
-use specs::prelude::*;
-use settings;
 use components as c;
 use resources as r;
+use settings;
+use specs::prelude::*;
 use std::time::Instant;
 
 pub struct BlockSpawner;
@@ -11,7 +11,7 @@ impl<'a> System<'a> for BlockSpawner {
         Entities<'a>,
         WriteExpect<'a, r::Clock>,
         Read<'a, LazyUpdate>,
-        WriteExpect<'a, r::Actions>
+        WriteExpect<'a, r::Actions>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
@@ -34,24 +34,36 @@ impl<'a> System<'a> for BlockSpawner {
 
 fn spawn(updater: &Read<LazyUpdate>, entities: &Entities) -> specs::Entity {
     let new_block = entities.create();
-    updater.insert(new_block, c::Dimensions {
-        width: settings::RECT_WIDTH,
-        height: settings::RECT_HEIGHT});
+    updater.insert(
+        new_block,
+        c::Dimensions {
+            width: settings::RECT_WIDTH,
+            height: settings::RECT_HEIGHT,
+        },
+    );
     updater.insert(new_block, c::Position { x: 0.0, y: 0.0 });
-    updater.insert(new_block, c::Color {
-        r: 1.0,
-        g: 0.0,
-        b: 0.0,
-        a: 1.0});
+    updater.insert(
+        new_block,
+        c::Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+    );
     updater.insert(new_block, c::DropSpeed(settings::STANDARD_DROP_SPEED));
     updater.insert(new_block, c::Active(true));
     new_block
 }
 
 fn make_l_block(updater: &Read<LazyUpdate>, entity: &Entity) {
-    updater.insert(*entity, c::BlockOffsets (
-        [c::Offset {x: 0, y: 0},
-        c::Offset {x: 1, y: 0}, 
-        c::Offset {x: 0, y: -1}, 
-        c::Offset {x: 0, y: -2}]));
+    updater.insert(
+        *entity,
+        c::BlockOffsets([
+            c::Offset { x: 0, y: 0 },
+            c::Offset { x: 1, y: 0 },
+            c::Offset { x: 0, y: -1 },
+            c::Offset { x: 0, y: -2 },
+        ]),
+    );
 }

--- a/src/sys/spawn.rs
+++ b/src/sys/spawn.rs
@@ -3,6 +3,7 @@ use resources as r;
 use settings;
 use specs::prelude::*;
 use std::time::Instant;
+use utils::Offset;
 
 pub struct BlockSpawner;
 
@@ -60,10 +61,10 @@ fn make_l_block(updater: &Read<LazyUpdate>, entity: &Entity) {
     updater.insert(
         *entity,
         c::BlockOffsets([
-            c::Offset { x: 0, y: 0 },
-            c::Offset { x: 1, y: 0 },
-            c::Offset { x: 0, y: -1 },
-            c::Offset { x: 0, y: -2 },
+            Offset { x: 0, y: 0 },
+            Offset { x: 1, y: 0 },
+            Offset { x: 0, y: -1 },
+            Offset { x: 0, y: -2 },
         ]),
     );
 }

--- a/src/sys/spawn.rs
+++ b/src/sys/spawn.rs
@@ -11,7 +11,7 @@ impl<'a> System<'a> for BlockSpawner {
         Entities<'a>,
         WriteExpect<'a, r::Clock>,
         Read<'a, LazyUpdate>,
-        WriteExpect<'a, r::Actions>,
+        WriteExpect<'a, r::Actions>
     );
 
     fn run(&mut self, data: Self::SystemData) {
@@ -23,30 +23,35 @@ impl<'a> System<'a> for BlockSpawner {
 
         if secs_since_spawn > settings::MAX_SPAWN_SPEED {
             if actions.spawn_block {
-                let new_block = entities.create();
-                updater.insert(
-                    new_block,
-                    c::Dimensions {
-                        width: settings::RECT_WIDTH,
-                        height: settings::RECT_HEIGHT,
-                    },
-                );
-                updater.insert(new_block, c::Position { x: 0.0, y: 0.0 });
-                updater.insert(
-                    new_block,
-                    c::Color {
-                        r: 1.0,
-                        g: 0.0,
-                        b: 0.0,
-                        a: 1.0,
-                    },
-                );
-                updater.insert(new_block, c::DropSpeed(settings::STANDARD_DROP_SPEED));
-                updater.insert(new_block, c::Active(true));
-
+                let new_block = spawn(&updater, &entities);
+                make_l_block(&updater, &new_block);
                 clock.last_spawn = Instant::now();
                 actions.spawn_block = false;
             }
         }
     }
+}
+
+fn spawn(updater: &Read<LazyUpdate>, entities: &Entities) -> specs::Entity {
+    let new_block = entities.create();
+    updater.insert(new_block, c::Dimensions {
+        width: settings::RECT_WIDTH,
+        height: settings::RECT_HEIGHT});
+    updater.insert(new_block, c::Position { x: 0.0, y: 0.0 });
+    updater.insert(new_block, c::Color {
+        r: 1.0,
+        g: 0.0,
+        b: 0.0,
+        a: 1.0});
+    updater.insert(new_block, c::DropSpeed(settings::STANDARD_DROP_SPEED));
+    updater.insert(new_block, c::Active(true));
+    new_block
+}
+
+fn make_l_block(updater: &Read<LazyUpdate>, entity: &Entity) {
+    updater.insert(*entity, c::BlockOffsets (
+        [c::Offset {x: 0, y: 0},
+        c::Offset {x: 1, y: 0}, 
+        c::Offset {x: 0, y: -1}, 
+        c::Offset {x: 0, y: -2}]));
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,11 @@
+#[derive(Debug)]
+pub struct Offset {
+    pub x: i8,
+    pub y: i8,
+}
+
+#[derive(Debug)]
+pub struct Coordinates {
+    pub x: i16,
+    pub y: i16,
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,6 @@
+use components as c;
+use settings;
+
 #[derive(Debug)]
 pub struct Offset {
     pub x: i8,
@@ -8,4 +11,13 @@ pub struct Offset {
 pub struct Coordinates {
     pub x: i16,
     pub y: i16,
+}
+
+impl Coordinates {
+    pub fn get_position(&self) -> c::Position {
+        c::Position {
+            x: (self.x as f64) * settings::RECT_WIDTH,
+            y: (self.y as f64) * settings::RECT_HEIGHT,
+        }
+    }
 }


### PR DESCRIPTION
- Create `Offset` helper struct, combined with new compenent `BlockOffsets` to define block shape via set of offsets from position
- Refactor game map to be a multi-dimensional array that tracks inactive blocks
- Create `Coordinates` helper struct to interface with game map
- Implement a number of helper functions throughout, general refactoring

Todo:
- Define different types of blocks via a bunch of `const [Offset; 4]` variables that live in some new file
- Refactor block spawner to accept these constants when creating new blocks
- Before moving left or right, check GameMap for inactive blocks that are in the way

Note: 
- In order to implement spinning blocks, a match statement could be used that converts a `BlockOffset` into it's next iteration. 

For example the L blocks starts as...

0, 0
0, -1
0, -2
1, 0

then spins to become...

0, 0
0, -1
1, -1
2, -1